### PR TITLE
Fix proxy parser

### DIFF
--- a/parsers/find_proxy.py
+++ b/parsers/find_proxy.py
@@ -3,22 +3,45 @@ from bs4 import BeautifulSoup
 
 # Получение списка бесплатных http/https прокси с сайта
 def get_free_proxies():
-    url = 'https://free-proxy-list.net/'
-    headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36'}
-    response = requests.get(url, headers=headers)
-    soup = BeautifulSoup(response.text, 'html.parser')
-    table = soup.find('table', id='proxylisttable')
+    """Возвращает список прокси из таблицы на free-proxy-list.net."""
+    url = "https://free-proxy-list.net/"
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36"
+        )
+    }
+
+    response = requests.get(url, headers=headers, timeout=10)
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    # На сайте таблица может иметь разные атрибуты, поэтому ищем несколько вариантов
+    table = soup.find("table", id="proxylisttable")
     if not table:
-        print('Не удалось найти таблицу с прокси! Проверь источник или сайт заблокирован.')
+        proxy_div = soup.find("div", class_="fpl-list")
+        if proxy_div:
+            table = proxy_div.find("table")
+
+    if not table:
+        print(
+            "Не удалось найти таблицу с прокси! Проверь источник или сайт заблокирован."
+        )
         return []
+
+    rows = table.tbody.find_all("tr") if table.tbody else table.find_all("tr")
     proxies = []
-    for row in table.tbody.find_all('tr'):
-        cols = row.find_all('td')
-        ip = cols[0].text.strip()
-        port = cols[1].text.strip()
-        https = cols[6].text.strip()
-        if https == "yes":
-            proxies.append(f"http://{ip}:{port}")
+    for row in rows:
+        cells = [td.get_text(strip=True) for td in row.find_all("td")]
+        # Строки таблицы должны содержать не менее 7 ячеек: IP, порт и флаг Https
+        if len(cells) < 7:
+            continue
+
+        ip = cells[0]
+        port = cells[1]
+        https = cells[6].lower().startswith("yes")
+        scheme = "https" if https else "http"
+        proxies.append(f"{scheme}://{ip}:{port}")
+
     return proxies
 
 # Проверка — можно ли через прокси достучаться до YouTube


### PR DESCRIPTION
## Summary
- improve searching for proxy table in `get_free_proxies`
- better detection of https value

## Testing
- `python -m py_compile parsers/find_proxy.py`
- `python parsers/find_proxy.py` *(fails: ProxyError due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684d99cc30b483278caa4595f7884eab